### PR TITLE
fix: Adds namespace creation dependency for role binding resource

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -346,7 +346,7 @@ resource "kubernetes_role_binding_v1" "this" {
 
   metadata {
     name        = "${coalesce(var.role_name, var.name)}-${each.key}"
-    namespace   = each.key
+    namespace   = try(each.value.create, true) ? kubernetes_namespace_v1.this[each.key].metadata[0].name : each.key
     annotations = var.annotations
     labels      = var.labels
   }
@@ -364,7 +364,7 @@ resource "kubernetes_role_binding_v1" "this" {
     kind      = "Group"
     name      = var.name
     api_group = "rbac.authorization.k8s.io"
-    namespace = each.key
+    namespace = try(each.value.create, true) ? kubernetes_namespace_v1.this[each.key].metadata[0].name : each.key
   }
 }
 


### PR DESCRIPTION
### What does this PR do?

Creates a dependency on namespace creation before creating role binding inside namespace

### Motivation

- Resolves #8

### More

- [ ] Yes, I have tested the PR using my local account setup (Provide any test evidence report under Additional Notes)
- [x] Yes, I ran `pre-commit run -a` with this PR

### For Moderators

- [ ] E2E Test successfully complete before merge?

### Additional Notes

<!-- Anything else we should know when reviewing? -->
