### PR TITLE
feat: Add support for `image_pull_secrets` on service account

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -10,7 +10,7 @@ repos:
       - id: detect-aws-credentials
         args: ['--allow-missing-credentials']
   - repo: https://github.com/antonbabenko/pre-commit-terraform
-    rev: v1.77.1
+    rev: v1.79.1
     hooks:
       - id: terraform_fmt
       - id: terraform_docs

--- a/main.tf
+++ b/main.tf
@@ -200,6 +200,14 @@ resource "kubernetes_service_account_v1" "this" {
     labels = merge(var.labels, try(each.value.service_account.labels, {}))
   }
 
+  dynamic "image_pull_secret" {
+    for_each = try(each.value.service_account.image_pull_secrets, [])
+
+    content {
+      name = secret.value.name
+    }
+  }
+
   dynamic "secret" {
     for_each = try(each.value.service_account.secrets, [])
 


### PR DESCRIPTION
### What does this PR do?

- Add support for `image_pull_secrets` on service account

### Motivation

- Resolves #10

### More

- [ ] Yes, I have tested the PR using my local account setup (Provide any test evidence report under Additional Notes)
- [x] Yes, I ran `pre-commit run -a` with this PR

### For Moderators

- [ ] E2E Test successfully complete before merge?

### Additional Notes

<!-- Anything else we should know when reviewing? -->
