### PR TITLE
fix: Correct image_pull_secret dynamic block iterator

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -204,7 +204,7 @@ resource "kubernetes_service_account_v1" "this" {
     for_each = try(each.value.service_account.image_pull_secrets, [])
 
     content {
-      name = secret.value.name
+      name = image_pull_secret.value.name
     }
   }
 


### PR DESCRIPTION
### What does this PR do?

Fixes the iterator on the `image_pull_secrets` dynamic block.  

### Motivation

```terraform
module "team" {
source = "github.com/aws-ia/terraform-aws-eks-blueprints-teams?ref=afc511ccb9c2b747fb05a79aeceb7c66be74cf6f"
//... omitting required inputs for brevity

  namespaces = {
    "team_a_ns" = {
      service_account = {
        image_pull_secrets = [{name = "image-pull-secret-docker"}]
      }
    }
  }
}
```
Produces the following error:

```sh
│ Error: Reference to undeclared resource
│
│   on .terraform/modules/team/main.tf line 207, in resource "kubernetes_service_account_v1" "this":
│  207:       name = secret.value.name

A managed resource "secret" "value" has not been declared in module.team.
```
I _think_ the iterator should match the dynamic block name. Updating the terraform to use `image_pull_secrets.value.name` fixes the issue. 

### More

- [ ] Yes, I have tested the PR using my local account setup (Provide any test evidence report under Additional Notes)
- [ ] Yes, I ran `pre-commit run -a` with this PR

### For Moderators

- [ ] E2E Test successfully complete before merge?

### Additional Notes

None.
