### PR TITLE
docs: Update docs to use Terraform registry URL and latest module versions

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -10,7 +10,7 @@ repos:
       - id: detect-aws-credentials
         args: ['--allow-missing-credentials']
   - repo: https://github.com/antonbabenko/pre-commit-terraform
-    rev: v1.79.1
+    rev: v1.80.0
     hooks:
       - id: terraform_fmt
       - id: terraform_docs

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ See [`tests`](https://github.com/aws-ia/terraform-aws-eks-blueprints-teams/tree/
 
 ```hcl
 module "admin_team" {
-  source = "https://github.com/aws-ia/terraform-aws-eks-blueprints-teams"
+  source = "aws-ia/eks-blueprints-teams/aws"
 
   name = "admin-team"
 
@@ -30,7 +30,7 @@ module "admin_team" {
 
 ```hcl
 module "development_team" {
-  source = "https://github.com/aws-ia/terraform-aws-eks-blueprints-teams"
+  source = "aws-ia/eks-blueprints-teams/aws"
 
   name = "development-team"
 
@@ -38,7 +38,7 @@ module "development_team" {
   cluster_arn       = "arn:aws:eks:us-west-2:012345678901:cluster/my-cluster"
   oidc_provider_arn = "arn:aws:iam::012345678901:oidc-provider/oidc.eks.us-west-2.amazonaws.com/id/5C54DDF35ER19312844C7333374CC09D"
 
-  # Lables applied to all Kubernetes resources
+  # Labels applied to all Kubernetes resources
   # More specific labels can be applied to individual resources under `namespaces` below
   labels = {
     team = "development"
@@ -162,7 +162,7 @@ You can utilize a module level `for_each` to create multiple teams with the same
 
 ```hcl
 module "development_team" {
-  source = "https://github.com/aws-ia/terraform-aws-eks-blueprints-teams"
+  source = "aws-ia/eks-blueprints-teams/aws"
 
   for_each = {
     one = {
@@ -183,7 +183,7 @@ module "development_team" {
   cluster_arn       = "arn:aws:eks:us-west-2:012345678901:cluster/my-cluster"
   oidc_provider_arn = "arn:aws:iam::012345678901:oidc-provider/oidc.eks.us-west-2.amazonaws.com/id/5C54DDF35ER19312844C7333374CC09D"
 
-  # Lables applied to all Kubernetes resources
+  # Labels applied to all Kubernetes resources
   # More specific labels can be applied to individual resources under `namespaces` below
   labels = {
     team = each.key

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
-# AWS EKS Multi-Tenancy Terraform module
+# Amazon EKS Blueprints Teams Terraform module
 
-Terraform module which creates EKS Multi-Tenancy resources.
+Terraform module which creates multi-tenancy resources on Amazon EKS.
 
 ## Usage
 

--- a/tests/README.md
+++ b/tests/README.md
@@ -1,3 +1,3 @@
-# Terraform AWS EKS Multi-Tenancy Tests
+# Amazon EKS Blueprints Teams
 
 - [Complete](https://github.com/aws-ia/terraform-aws-eks-blueprints-teams/tree/main/tests/complete)

--- a/tests/complete/README.md
+++ b/tests/complete/README.md
@@ -1,8 +1,8 @@
-# Complete AWS EKS Multi-Tenancy Example
+# Amazon EKS Blueprints Teams - Complete
 
 Configuration in this directory creates:
 
-- An EKS cluster for demonstration
+- An EKS cluster (required to support module/tests)
 - An administrative team
 - A red team which demonstrates creating one team per module definition
 - Blue teams which demonstrates creating multiple teams per module definition

--- a/tests/complete/README.md
+++ b/tests/complete/README.md
@@ -40,9 +40,9 @@ Note that this example may create resources which will incur monetary charges on
 |------|--------|---------|
 | <a name="module_admin_team"></a> [admin\_team](#module\_admin\_team) | ../.. | n/a |
 | <a name="module_blue_teams"></a> [blue\_teams](#module\_blue\_teams) | ../.. | n/a |
-| <a name="module_eks"></a> [eks](#module\_eks) | terraform-aws-modules/eks/aws | ~> 19.10 |
+| <a name="module_eks"></a> [eks](#module\_eks) | terraform-aws-modules/eks/aws | ~> 19.13 |
 | <a name="module_red_team"></a> [red\_team](#module\_red\_team) | ../.. | n/a |
-| <a name="module_vpc"></a> [vpc](#module\_vpc) | terraform-aws-modules/vpc/aws | ~> 3.0 |
+| <a name="module_vpc"></a> [vpc](#module\_vpc) | terraform-aws-modules/vpc/aws | ~> 5.0 |
 
 ## Resources
 

--- a/tests/complete/main.tf
+++ b/tests/complete/main.tf
@@ -209,10 +209,10 @@ module "blue_teams" {
 
 module "eks" {
   source  = "terraform-aws-modules/eks/aws"
-  version = "~> 19.10"
+  version = "~> 19.13"
 
   cluster_name                   = local.name
-  cluster_version                = "1.24"
+  cluster_version                = "1.27"
   cluster_endpoint_public_access = true
 
   vpc_id     = module.vpc.vpc_id
@@ -229,18 +229,20 @@ module "eks" {
   }
 
   manage_aws_auth_configmap = true
-  aws_auth_roles = flatten([
-    module.admin_team.aws_auth_configmap_role,
-    module.red_team.aws_auth_configmap_role,
-    [for team in module.blue_teams : team.aws_auth_configmap_role],
-  ])
+  aws_auth_roles = flatten(
+    [
+      module.admin_team.aws_auth_configmap_role,
+      module.red_team.aws_auth_configmap_role,
+      [for team in module.blue_teams : team.aws_auth_configmap_role],
+    ]
+  )
 
   tags = local.tags
 }
 
 module "vpc" {
   source  = "terraform-aws-modules/vpc/aws"
-  version = "~> 3.0"
+  version = "~> 5.0"
 
   name = local.name
   cidr = local.vpc_cidr
@@ -249,17 +251,8 @@ module "vpc" {
   private_subnets = [for k, v in local.azs : cidrsubnet(local.vpc_cidr, 4, k)]
   public_subnets  = [for k, v in local.azs : cidrsubnet(local.vpc_cidr, 8, k + 48)]
 
-  enable_nat_gateway   = true
-  single_nat_gateway   = true
-  enable_dns_hostnames = true
-
-  # Manage so we can name
-  manage_default_network_acl    = true
-  default_network_acl_tags      = { Name = "${local.name}-default" }
-  manage_default_route_table    = true
-  default_route_table_tags      = { Name = "${local.name}-default" }
-  manage_default_security_group = true
-  default_security_group_tags   = { Name = "${local.name}-default" }
+  enable_nat_gateway = true
+  single_nat_gateway = true
 
   public_subnet_tags = {
     "kubernetes.io/role/elb" = 1


### PR DESCRIPTION
### What does this PR do?

- Update docs to use Terraform registry URL and latest module versions

### Motivation

- Doc updates before 1.0 release

### More

- [ ] Yes, I have tested the PR using my local account setup (Provide any test evidence report under Additional Notes)
- [ ] Yes, I ran `pre-commit run -a` with this PR

### For Moderators

- [ ] E2E Test successfully complete before merge?

### Additional Notes

<!-- Anything else we should know when reviewing? -->
