### PR TITLE
refactor: Admins Team permissions.

### DIFF
--- a/README.md
+++ b/README.md
@@ -274,6 +274,7 @@ No modules.
 | [aws_iam_role.this](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role) | resource |
 | [aws_iam_role_policy_attachment.admin](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role_policy_attachment) | resource |
 | [aws_iam_role_policy_attachment.this](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role_policy_attachment) | resource |
+| [kubernetes_cluster_role_binding_v1.admin](https://registry.terraform.io/providers/hashicorp/kubernetes/latest/docs/resources/cluster_role_binding_v1) | resource |
 | [kubernetes_cluster_role_binding_v1.this](https://registry.terraform.io/providers/hashicorp/kubernetes/latest/docs/resources/cluster_role_binding_v1) | resource |
 | [kubernetes_cluster_role_v1.this](https://registry.terraform.io/providers/hashicorp/kubernetes/latest/docs/resources/cluster_role_v1) | resource |
 | [kubernetes_limit_range_v1.this](https://registry.terraform.io/providers/hashicorp/kubernetes/latest/docs/resources/limit_range_v1) | resource |

--- a/main.tf
+++ b/main.tf
@@ -310,7 +310,7 @@ resource "kubernetes_cluster_role_binding_v1" "admin" {
   count = var.create_cluster_role && var.enable_admin ? 1 : 0
 
   metadata {
-    name        = "${coalesce(var.role_name, var.name)}"
+    name        = coalesce(var.role_name, var.name)
     annotations = var.annotations
     labels      = var.labels
   }
@@ -318,7 +318,7 @@ resource "kubernetes_cluster_role_binding_v1" "admin" {
   role_ref {
     api_group = "rbac.authorization.k8s.io"
     kind      = "ClusterRole"
-    name      = "cluster-admin"
+    name      = "admin"
   }
 
   subject {

--- a/main.tf
+++ b/main.tf
@@ -303,6 +303,33 @@ resource "kubernetes_limit_range_v1" "this" {
 }
 
 ################################################################################
+# K8s Admin ClusterRole Binding
+################################################################################
+
+resource "kubernetes_cluster_role_binding_v1" "admin" {
+  count = var.create_cluster_role && var.enable_admin ? 1 : 0
+
+  metadata {
+    name        = "${coalesce(var.role_name, var.name)}"
+    annotations = var.annotations
+    labels      = var.labels
+  }
+
+  role_ref {
+    api_group = "rbac.authorization.k8s.io"
+    kind      = "ClusterRole"
+    name      = "cluster-admin"
+  }
+
+  subject {
+    kind      = "Group"
+    name      = var.name
+    api_group = "rbac.authorization.k8s.io"
+    namespace = ""
+  }
+}
+
+################################################################################
 # K8s Cluster Role
 ################################################################################
 
@@ -321,6 +348,10 @@ resource "kubernetes_cluster_role_v1" "this" {
     verbs      = ["get", "list", "watch"]
   }
 }
+
+################################################################################
+# K8s ClusterRole Binding
+################################################################################
 
 resource "kubernetes_cluster_role_binding_v1" "this" {
   count = var.create_cluster_role && !var.enable_admin ? 1 : 0

--- a/outputs.tf
+++ b/outputs.tf
@@ -13,7 +13,7 @@ output "namespaces" {
 
 output "rbac_group" {
   description = "The name of the Kubernetes RBAC group"
-  value       = var.enable_admin ? "system:masters" : var.name
+  value       = var.enable_admin ? "admin-team" : var.name
 }
 
 output "aws_auth_configmap_role" {
@@ -21,7 +21,7 @@ output "aws_auth_configmap_role" {
   value = {
     rolearn  = try(aws_iam_role.this[0].arn, var.iam_role_arn)
     username = var.name
-    groups   = [var.enable_admin ? "system:masters" : var.name]
+    groups   = [var.enable_admin ? "admin-team" : var.name]
   }
 }
 

--- a/outputs.tf
+++ b/outputs.tf
@@ -13,7 +13,7 @@ output "namespaces" {
 
 output "rbac_group" {
   description = "The name of the Kubernetes RBAC group"
-  value       = var.enable_admin ? "admin-team" : var.name
+  value       = var.name
 }
 
 output "aws_auth_configmap_role" {
@@ -21,7 +21,7 @@ output "aws_auth_configmap_role" {
   value = {
     rolearn  = try(aws_iam_role.this[0].arn, var.iam_role_arn)
     username = var.name
-    groups   = [var.enable_admin ? "admin-team" : var.name]
+    groups   = [var.name]
   }
 }
 

--- a/tests/complete/main.tf
+++ b/tests/complete/main.tf
@@ -40,9 +40,10 @@ module "admin_team" {
 
   name = "admin-team"
 
-  enable_admin = true
-  users        = [data.aws_caller_identity.current.arn]
-  cluster_arn  = module.eks.cluster_arn
+  enable_admin      = true
+  users             = [data.aws_caller_identity.current.arn]
+  cluster_arn       = module.eks.cluster_arn
+  oidc_provider_arn = module.eks.oidc_provider_arn
 
   tags = local.tags
 }


### PR DESCRIPTION
### What does this PR do?

🛑 Please open an issue first to discuss any significant work and flesh out details/direction - we would hate for your time to be wasted.
Consult the [CONTRIBUTING](https://github.com/aws-ia/terraform-aws-eks-blueprints-teams/blob/main/.github/CONTRIBUTING.md#contributing-via-pull-requests) guide for submitting pull-requests.

<!-- A brief description of the change being made with this pull request. -->

### Motivation

This PR intends to remove the Kubernetes group `system:masters` from the module when using the variable `enable_admin=true` as a security recommendation. To replace it, the module will create a new `clusterRoleBinding` tied to the `admin` `clusterRole` to give administrator access (but not unrestricted access) to "Admin" teams.


<!-- What inspired you to submit this pull request? -->
- Resolves #17 

### More

- [X] Yes, I have tested the PR using my local account setup (Provide any test evidence report under Additional Notes)
- [X] Yes, I ran `pre-commit run -a` with this PR

### For Moderators

- [ ] E2E Test successfully complete before merge?

### Additional Notes

<!-- Anything else we should know when reviewing? -->
